### PR TITLE
Fix - Middleware crashes without logger

### DIFF
--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -3,11 +3,7 @@ import Redis from 'redis';
 import {MongoClient} from 'mongodb';
 import Sequelize from 'sequelize';
 import httpMocks from 'node-mocks-http';
-import Acl from '../src/classes/acl';
-import MemoryStore from '../src/stores/memory';
-import RedisStore from '../src/stores/redis';
-import MongoDBStore from '../src/stores/mongodb';
-import SequelizeStore from '../src/stores/sequelize';
+import {Acl, MemoryStore, RedisStore, MongoDBStore, SequelizeStore} from '../src';
 
 jest.setTimeout(10000);
 let mongoClient = null;
@@ -140,15 +136,9 @@ let mongoClient = null;
 
     describe('Middleware', () => {
       it('should fallback to dummy logger', (done) => {
-        const request = httpMocks.createRequest({
-          method: 'GET',
-          url: '/blogs',
-        });
-
+        const request = httpMocks.createRequest({method: 'GET', url: '/blogs'});
         const response = httpMocks.createResponse();
-
         acl.middleware(0, 'joed', 'GET')(request, response, (err) => {
-          // TODO returns HttpError 403
           expect(err);
           done();
         });

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -135,11 +135,13 @@ let mongoClient = null;
     });
 
     describe('Middleware', () => {
-      it('should fallback to dummy logger', (done) => {
+      it('Should return 403', (done) => {
         const request = httpMocks.createRequest({method: 'GET', url: '/blogs'});
         const response = httpMocks.createResponse();
         acl.middleware(0, 'joed', 'GET')(request, response, (err) => {
-          expect(err);
+          expect(err.name).toEqual('HttpError');
+          expect(err.errorCode).toEqual(403);
+          expect(err.message).toEqual('Insufficient permissions to access resource');
           done();
         });
       });

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -145,6 +145,17 @@ let mongoClient = null;
           done();
         });
       });
+
+      it('Should return 401', (done) => {
+        const request = httpMocks.createRequest({method: 'GET', url: '/blogs'});
+        const response = httpMocks.createResponse();
+        acl.middleware(0, null, 'GET')(request, response, (err) => {
+          expect(err.name).toEqual('HttpError');
+          expect(err.errorCode).toEqual(401);
+          expect(err.message).toEqual('User not authenticated');
+          done();
+        });
+      });
     });
 
     describe('Read user\'s roles', () => {

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -45,7 +45,7 @@ let mongoClient = null;
         else if (store === 'MongoDB') mongoClient.close();
         else if (store === 'MySQL') acl.store.db.close();
         done();
-      }, 5000);
+      }, 14000);
     });
 
     describe('Constructor', () => {
@@ -156,890 +156,906 @@ let mongoClient = null;
           done();
         });
       });
-    });
 
-    describe('Read user\'s roles', () => {
-      it('Run userRoles function', (done) => {
-        acl.addUserRoles('harry', 'admin', (err1) => {
-          if (err1) done(err1);
-
-          acl.userRoles('harry', (err2, roles) => {
-            if (err2) done(err2);
-            expect(roles).toEqual(['admin']);
-
-            acl.hasRole('harry', 'admin', (err3, isInRole1) => {
-              if (err3) done(err3);
-              expect(isInRole1).toBeTruthy();
-
-              acl.hasRole('harry', 'no role', (err4, isInRole2) => {
-                if (err4) done(err4);
-                expect(isInRole2).toBeFalsy();
-                done();
-              });
-            });
-          });
-        });
+      it('Should return 200', (done) => {
+        const request = httpMocks.createRequest({method: 'POST', url: '/blogs'});
+        const response = httpMocks.createResponse();
+        acl.addUserRoles('joed', 'member')
+          .then(() => acl.allow('member', '/blogs', ['POST']))
+          .then(() => acl.isAllowed('joed', '/blogs', 'POST'))
+          .then(() => acl.middleware(0, 'joed', 'POST')(request, response, (err2) => {
+            setTimeout(() => {
+              expect(!err2);
+              expect(response.statusCode).toEqual(200);
+              expect(response.statusMessage).toEqual('OK');
+              done();
+            }, 2000);
+          }));
       });
     });
-
-    describe('Read role\'s users', () => {
-      it('Run roleUsers function', (done) => {
-        acl.addUserRoles('harry', 'admin', (err1) => {
-          if (err1) done(err1);
-
-          acl.roleUsers('admin', (err2, users) => {
-            if (err2) done(err2);
-            expect(users).toContain('harry');
-            done();
-          });
-        });
-      });
-    });
-
-    describe('Allow', () => {
-      it('Admin view/add/edit/delete users', (done) => {
-        acl.allow('admin', 'users', ['add', 'edit', 'view', 'delete'], (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Foo view/edit blogs', (done) => {
-        acl.allow('foo', 'blogs', ['edit', 'view'], (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Bar to view/delete blogs', (done) => {
-        acl.allow('bar', 'blogs', ['view', 'delete'], (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('Add role parents', () => {
-      it('Add foot and bar roles into baz parent role', (done) => {
-        acl.addRoleParents('baz', ['foo', 'bar'], (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('Add user roles', () => {
-      it('Add them', (done) => {
-        acl.addUserRoles('dimitri', 'baz', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Add them with numeric userId', (done) => {
-        acl.addUserRoles(3, 'baz', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('allow admin to do anything', () => {
-      it('Add them', (done) => {
-        acl.allow('admin', ['blogs', 'forums'], '*', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('Arguments in one array', () => {
-      it('Give role fumanchu an array of resources and permissions', (done) => {
-        acl.allow(
-          [{
-            roles: 'fumanchu',
-            allows: [
-              {resources: 'blogs', permissions: 'get'},
-              {resources: ['forums', 'news'], permissions: ['get', 'put', 'delete']},
-              {resources: ['/path/file/file1.txt', '/path/file/file2.txt'], permissions: ['get', 'put', 'delete']},
-            ],
-          }],
-          (err) => {
-            expect(!err);
-            done();
-          },
-        );
-      });
-    });
-
-    describe('Add fumanchu role to suzanne', () => {
-      it('Do it', (done) => {
-        acl.addUserRoles('suzanne', 'fumanchu', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Do it (numeric userId)', (done) => {
-        acl.addUserRoles(4, 'fumanchu', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-
-    describe('Allowance queries', () => {
-      describe('IsAllowed', () => {
-        it('Can joed view blogs?', (done) => {
-          acl.isAllowed('joed', 'blogs', 'view', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can userId=0 view blogs?', (done) => {
-          acl.isAllowed(0, 'blogs', 'view', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can joed view forums?', (done) => {
-          acl.isAllowed('joed', 'forums', 'view', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can userId=0 view forums?', (done) => {
-          acl.isAllowed(0, 'forums', 'view', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can joed edit forums?', (done) => {
-          acl.isAllowed('joed', 'forums', 'edit', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can userId=0 edit forums?', (done) => {
-          acl.isAllowed(0, 'forums', 'edit', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can jsmith edit forums?', (done) => {
-          acl.isAllowed('jsmith', 'forums', 'edit', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can jsmith edit forums?', (done) => {
-          acl.isAllowed('jsmith', 'forums', 'edit', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-
-        it('Can jsmith edit blogs?', (done) => {
-          acl.isAllowed('jsmith', 'blogs', 'edit', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can test@test.com edit forums?', (done) => {
-          acl.isAllowed('test@test.com', 'forums', 'edit', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can test@test.com edit forums?', (done) => {
-          acl.isAllowed('test@test.com', 'forums', 'edit', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can test@test.com edit blogs?', (done) => {
-          acl.isAllowed('test@test.com', 'blogs', 'edit', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can userId=1 edit blogs?', (done) => {
-          acl.isAllowed(1, 'blogs', 'edit', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can jsmith edit, delete and clone blogs?', (done) => {
-          acl.isAllowed('jsmith', 'blogs', ['edit', 'view', 'clone'], (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can test@test.com edit, delete and clone blogs?', (done) => {
-          acl.isAllowed('test@test.com', 'blogs', ['edit', 'view', 'clone'], (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can userId=1 edit, delete and clone blogs?', (done) => {
-          acl.isAllowed(1, 'blogs', ['edit', 'view', 'clone'], (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can jsmith edit, clone blogs?', (done) => {
-          acl.isAllowed('jsmith', 'blogs', ['edit', 'clone'], (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can test@test.com edit, clone blogs?', (done) => {
-          acl.isAllowed('test@test.com', 'blogs', ['edit', 'clone'], (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can userId=1 edit, delete blogs?', (done) => {
-          acl.isAllowed(1, 'blogs', ['edit', 'clone'], (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can james add blogs?', (done) => {
-          acl.isAllowed('dimitri', 'blogs', 'add', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-
-        it('Can userId=3 add blogs?', (done) => {
-          acl.isAllowed(3, 'blogs', 'add', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can suzanne add blogs?', (done) => {
-          acl.isAllowed('suzanne', 'blogs', 'add', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can userId=4 add blogs?', (done) => {
-          acl.isAllowed(4, 'blogs', 'add', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can suzanne get blogs?', (done) => {
-          acl.isAllowed('suzanne', 'blogs', 'get', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can userId=4 get blogs?', (done) => {
-          acl.isAllowed(4, 'blogs', 'get', (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can suzanne delete and put news?', (done) => {
-          acl.isAllowed('suzanne', 'news', ['put', 'delete'], (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can userId=4 delete and put news?', (done) => {
-          acl.isAllowed(4, 'news', ['put', 'delete'], (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can suzanne delete and put forums?', (done) => {
-          acl.isAllowed('suzanne', 'forums', ['put', 'delete'], (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can userId=4 delete and put forums?', (done) => {
-          acl.isAllowed(4, 'forums', ['put', 'delete'], (err, allow) => {
-            expect(!err);
-            expect(allow);
-            done();
-          });
-        });
-
-        it('Can nobody view news?', (done) => {
-          acl.isAllowed('nobody', 'blogs', 'view', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-
-        it('Can nobody view nothing?', (done) => {
-          acl.isAllowed('nobody', 'nothing', 'view', (err, allow) => {
-            expect(!err);
-            expect(!allow);
-            done();
-          });
-        });
-      });
-    });
-
-    describe('allowedPermissions', () => {
-      it('What permissions has james over blogs and forums?', (done) => {
-        acl.allowedPermissions('dimitri', ['blogs', 'forums'], (err, permissions) => {
-          expect(!err);
-          expect(permissions).toHaveProperty('blogs');
-          expect(permissions).toHaveProperty('forums');
-          expect(permissions.blogs).toContain('edit');
-          expect(permissions.blogs).toContain('view');
-          expect(permissions.blogs).toContain('delete');
-          expect(!permissions.forums.length);
-          done();
-        });
-      });
-
-      it('What permissions has userId=3 over blogs and forums?', (done) => {
-        acl.allowedPermissions(3, ['blogs', 'forums'], (err, permissions) => {
-          expect(!err);
-          expect(permissions).toHaveProperty('blogs');
-          expect(permissions).toHaveProperty('forums');
-          expect(permissions.blogs).toContain('edit');
-          expect(permissions.blogs).toContain('view');
-          expect(permissions.blogs).toContain('delete');
-          expect(!permissions.forums.length);
-          done();
-        });
-      });
-
-      it('What permissions has nonsenseUser over blogs and forums?', (done) => {
-        acl.allowedPermissions('nonsense', ['blogs', 'forums'], (err, permissions) => {
-          expect(!err);
-          expect(!permissions.forums.length);
-          expect(!permissions.blogs.length);
-          done();
-        });
-      });
-    });
-
-    describe('WhatResources queries', () => {
-      it('What resources have "bar" some rights on?', (done) => {
-        acl.whatResources('bar', (err, resources) => {
-          expect(err).toBeNull();
-          expect(resources.blogs).toContain('view');
-          expect(resources.blogs).toContain('delete');
-          done();
-        });
-      });
-
-      it('What resources have "bar" view rights on?', (done) => {
-        acl.whatResources('bar', 'view', (err, resources) => {
-          expect(err).toBeNull();
-          expect(resources).toContain('blogs');
-          done();
-        });
-      });
-
-      it('What resources have "fumanchu" some rights on?', (done) => {
-        acl.whatResources('fumanchu', (err, resources) => {
-          expect(err).toBeNull();
-          expect(resources).toHaveProperty('blogs', ['get']);
-          expect(resources.forums).toContain('get');
-          expect(resources.forums).toContain('put');
-          expect(resources.forums).toContain('delete');
-          expect(resources.news).toContain('get');
-          expect(resources.news).toContain('put');
-          expect(resources.news).toContain('delete');
-          expect(resources['/path/file/file1.txt']).toContain('get');
-          expect(resources['/path/file/file1.txt']).toContain('put');
-          expect(resources['/path/file/file1.txt']).toContain('delete');
-          expect(resources['/path/file/file2.txt']).toContain('get');
-          expect(resources['/path/file/file2.txt']).toContain('put');
-          expect(resources['/path/file/file2.txt']).toContain('delete');
-          done();
-        });
-      });
-
-      it('What resources have "baz" some rights on?', (done) => {
-        acl.whatResources('baz', (err, resources) => {
-          expect(err).toBeNull();
-          expect(resources.blogs).toContain('edit');
-          expect(resources.blogs).toContain('view');
-          expect(resources.blogs).toContain('delete');
-          done();
-        });
-      });
-    });
-
-    describe('removeAllow', () => {
-      it('Remove get permissions from resources blogs and forums from role fumanchu', (done) => {
-        acl.removeAllow('fumanchu', ['blogs', 'forums'], 'get', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Remove delete and put permissions from resource news from role fumanchu', (done) => {
-        acl.removeAllow('fumanchu', 'news', 'delete', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Remove view permissions from resource blogs from role bar', (done) => {
-        acl.removeAllow('bar', 'blogs', 'view', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('See if permissions were removed', () => {
-      it('What resources have "fumanchu" some rights on after removed some of them?', (done) => {
-        acl.whatResources('fumanchu', (err, resources) => {
-          expect(err).toBeNull();
-          expect(resources).not.toContain('blogs');
-          expect(resources).toHaveProperty('news');
-          expect(resources.news).toContain('get');
-          expect(resources.news).toContain('put');
-          expect(resources).not.toContain('delete');
-          expect(resources.forums).toContain('put');
-          expect(resources.forums).toContain('delete');
-          done();
-        });
-      });
-    });
-
-    describe('RemoveRole', () => {
-      it('Remove role fumanchu', (done) => {
-        acl.removeRole('fumanchu', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Remove role member', (done) => {
-        acl.removeRole('member', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Remove role foo', (done) => {
-        acl.removeRole('foo', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('Was role removed?', () => {
-      it('What resources have "fumanchu" some rights on after removed?', (done) => {
-        acl.whatResources('fumanchu', (err, resources) => {
-          expect(!err);
-          expect(!Object.keys(resources).length);
-          done();
-        });
-      });
-
-      it('What resources have "member" some rights on after removed?', (done) => {
-        acl.whatResources('member', (err, resources) => {
-          expect(!err);
-          expect(!Object.keys(resources).length);
-          done();
-        });
-      });
-
-      describe('Allowed permissions', () => {
-        it('What permissions has jsmith over blogs and forums?', (done) => {
-          acl.allowedPermissions('jsmith', ['blogs', 'forums'], (err, permissions) => {
-            expect(!err);
-            expect(!permissions.blogs);
-            expect(!permissions.forums);
-            done();
-          });
-        });
-
-        it('What permissions has test@test.com over blogs and forums?', (done) => {
-          acl.allowedPermissions('test@test.com', ['blogs', 'forums'], (err, permissions) => {
-            expect(!err);
-            expect(!permissions.blogs);
-            expect(!permissions.forums);
-            done();
-          });
-        });
-
-        it('What permissions has james over blogs?', (done) => {
-          acl.allowedPermissions('dimitri', 'blogs', (err, permissions) => {
-            expect(!err);
-            expect(permissions.blogs).toContain('delete');
-            done();
-          });
-        });
-      });
-    });
-
-    describe('RoleParentRemoval', () => {
-      beforeAll((done) => {
-        acl.allow('parent1', 'x', 'read1')
-          .then(() => acl.allow('parent2', 'x', 'read2'))
-          .then(() => acl.allow('parent3', 'x', 'read3'))
-          .then(() => acl.allow('parent4', 'x', 'read4'))
-          .then(() => acl.allow('parent5', 'x', 'read5'))
-          .then(() => acl.addRoleParents('child', ['parent1', 'parent2', 'parent3', 'parent4', 'parent5']))
-          .then(() => done());
-      });
-
-      it('Environment check', (done) => {
-        acl.whatResources('child')
-          .then((resources) => {
-            expect(resources.x.length === 5);
-            expect(resources.x).toContain('read1');
-            expect(resources.x).toContain('read2');
-            expect(resources.x).toContain('read3');
-            expect(resources.x).toContain('read4');
-            expect(resources.x).toContain('read5');
-            done();
-          });
-      });
-
-      it('Operation uses a callback when removing a specific parent role', (done) => {
-        acl.removeRoleParents('child', 'parentX', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Operation uses a callback when removing multiple specific parent roles', (done) => {
-        acl.removeRoleParents('child', ['parentX', 'parentY'], (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Remove parent role "parentX" from role "child"', (done) => {
-        acl.removeRoleParents('child', 'parentX')
-          .then(() => acl.whatResources('child'))
-          .then((resources) => {
-            expect(resources.x.length === 5);
-            expect(resources.x).toContain('read1');
-            expect(resources.x).toContain('read2');
-            expect(resources.x).toContain('read3');
-            expect(resources.x).toContain('read4');
-            expect(resources.x).toContain('read5');
-            done();
-          });
-      });
-
-      it('Remove parent role "parent1" from role "child"', (done) => {
-        acl.removeRoleParents('child', 'parent1')
-          .then(() => acl.whatResources('child'))
-          .then((resources) => {
-            expect(resources.x.length === 4);
-            expect(resources.x).toContain('read2');
-            expect(resources.x).toContain('read3');
-            expect(resources.x).toContain('read4');
-            expect(resources.x).toContain('read5');
-            done();
-          });
-      });
-
-      it('Remove parent roles "parent2" & "parent3" from role "child"', (done) => {
-        acl.removeRoleParents('child', ['parent2', 'parent3'])
-          .then(() => acl.whatResources('child'))
-          .then((resources) => {
-            expect(resources.x.length === 2);
-            expect(resources.x).toContain('read4');
-            expect(resources.x).toContain('read5');
-            done();
-          });
-      });
-
-      it('Remove all parent roles from role "child"', (done) => {
-        acl.removeRoleParents('child')
-          .then(() => acl.whatResources('child'))
-          .then((resources) => {
-            expect(resources).not.toHaveProperty('x');
-            done();
-          });
-      });
-
-      it('Remove all parent roles from role "child" with no parents', (done) => {
-        acl.removeRoleParents('child')
-          .then(() => acl.whatResources('child'))
-          .then((resources) => {
-            expect(resources).not.toHaveProperty('x');
-            done();
-          });
-      });
-
-      it('Remove parent role "parent1" from role "child" with no parents', (done) => {
-        acl.removeRoleParents('child', 'parent1')
-          .then(() => acl.whatResources('child'))
-          .then((resources) => {
-            expect(resources).not.toHaveProperty('x');
-            done();
-          });
-      });
-
-      it('Operation uses a callback when removing all parent roles', (done) => {
-        acl.removeRoleParents('child', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('RemoveResource', () => {
-      it('Remove resource blogs', (done) => {
-        acl.removeResource('blogs', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Remove resource users', (done) => {
-        acl.removeResource('users', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('AllowedPermissions', () => {
-      it('What permissions has james over blogs?', (done) => {
-        acl.allowedPermissions('dimitri', 'blogs', (err, permissions) => {
-          expect(err).toBeNull();
-          expect(permissions).toHaveProperty('blogs');
-          expect(!permissions.blogs.length);
-          done();
-        });
-      });
-
-      it('What permissions has userId=4 over blogs?', (done) => {
-        acl.allowedPermissions(4, 'blogs')
-          .then((permissions) => {
-            expect(permissions).toHaveProperty('blogs');
-            expect(!permissions.blogs.length);
-            done();
-          });
-      });
-    });
-
-    describe('WhatResources', () => {
-      it('What resources have "baz" some rights on after removed blogs?', (done) => {
-        acl.whatResources('baz', (err, resources) => {
-          expect(!err);
-          expect(typeof resources === 'object');
-          expect(!Object.keys(resources).length);
-          done();
-        });
-      });
-
-      it('What resources have "admin" some rights on after removed users resource?', (done) => {
-        acl.whatResources('admin', (err, resources) => {
-          expect(!err);
-          expect(resources).not.toContain('users');
-          expect(resources).not.toContain('blogs');
-          done();
-        });
-      });
-    });
-
-    describe('Remove user roles', () => {
-      it('Remove role guest from joed', (done) => {
-        acl.removeUserRoles('joed', 'guest', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Remove role guest from userId=0', (done) => {
-        acl.removeUserRoles(0, 'guest', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-      it('Remove role admin from harry', (done) => {
-        acl.removeUserRoles('harry', 'admin', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Remove role admin from userId=2', (done) => {
-        acl.removeUserRoles(2, 'admin', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-    });
-
-    describe('Were roles removed?', () => {
-      it('What permissions has harry over forums and blogs?', (done) => {
-        acl.allowedPermissions('harry', ['forums', 'blogs'], (err, permissions) => {
-          expect(!err);
-          expect(typeof permissions === 'object');
-          expect(!permissions.forums.length);
-          done();
-        });
-      });
-
-      it('What permissions has userId=2 over forums and blogs?', (done) => {
-        acl.allowedPermissions(2, ['forums', 'blogs'], (err, permissions) => {
-          expect(!err);
-          expect(typeof permissions === 'object');
-          expect(!permissions.forums.length);
-          done();
-        });
-      });
-    });
-
-    describe('RemoveAllow is removing all permissions', () => {
-      it('Add roles/resources/permissions', () => {
-        acl.addUserRoles('jannette', 'member')
-          .then(() => acl.allow('member', 'blogs', ['view', 'update']))
-          .then(() => acl.isAllowed('jannette', 'blogs', 'view'))
-          .then((isAllowed) => expect(isAllowed).toBeTruthy())
-          .then(() => acl.removeAllow('member', 'blogs', 'update'))
-          .then(() => acl.isAllowed('jannette', 'blogs', 'view'))
-          .then((isAllowed) => expect(isAllowed).toBeTruthy())
-          .then(() => acl.isAllowed('jannette', 'blogs', 'update'))
-          .then((isAllowed) => expect(isAllowed).toBeFalsy())
-          .then(() => acl.removeAllow('member', 'blogs', 'view'))
-          .then(() => acl.isAllowed('jannette', 'blogs', 'view'))
-          .then((isAllowed) => expect(isAllowed).toBeFalsy());
-      });
-    });
-
-    describe('Removing a role removes the entire "allows" document.', () => {
-      it('Add roles/resources/permissions', (done) => {
-        acl.allow(['role1', 'role2', 'role3'], ['res1', 'res2', 'res3'], ['perm1', 'perm2', 'perm3'], (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Add user roles and parent roles', (done) => {
-        acl.addUserRoles('user1', 'role1', (err1) => {
-          expect(!err1);
-
-          acl.addRoleParents('role1', 'parentRole1', (err2) => {
-            expect(!err2);
-            done();
-          });
-        });
-      });
-
-      it('Add user roles and parent roles', (done) => {
-        acl.addUserRoles(1, 'role1', (err1) => {
-          expect(!err1);
-
-          acl.addRoleParents('role1', 'parentRole1', (err2) => {
-            expect(!err2);
-            done();
-          });
-        });
-      });
-
-      it('Verify that roles have permissions as assigned', (done) => {
-        acl.whatResources('role1', (err1, res1) => {
-          expect(!err1);
-          expect(res1.res1.sort()).toEqual(['perm1', 'perm2', 'perm3']);
-
-          acl.whatResources('role2', (err2, res2) => {
-            expect(!err2);
-            expect(res2.res1.sort()).toEqual(['perm1', 'perm2', 'perm3']);
-            done();
-          });
-        });
-      });
-
-      it('Remove role "role1"', (done) => {
-        acl.removeRole('role1', (err) => {
-          expect(!err);
-          done();
-        });
-      });
-
-      it('Verify that "role1" has no permissions and "role2" has permissions intact', (done) => {
-        acl.removeRole('role1', (err) => {
-          expect(!err);
-
-          acl.whatResources('role1', (err1, res1) => {
-            expect(!Object.keys(res1).length);
-
-            acl.whatResources('role2', (err2, res2) => {
-              expect(res2.res1.sort()).toEqual(['perm1', 'perm2', 'perm3']);
+  });
+
+  describe('Read user\'s roles', () => {
+    it('Run userRoles function', (done) => {
+      acl.addUserRoles('harry', 'admin', (err1) => {
+        if (err1) done(err1);
+
+        acl.userRoles('harry', (err2, roles) => {
+          if (err2) done(err2);
+          expect(roles).toEqual(['admin']);
+
+          acl.hasRole('harry', 'admin', (err3, isInRole1) => {
+            if (err3) done(err3);
+            expect(isInRole1).toBeTruthy();
+
+            acl.hasRole('harry', 'no role', (err4, isInRole2) => {
+              if (err4) done(err4);
+              expect(isInRole2).toBeFalsy();
               done();
             });
           });
         });
       });
+    });
+  });
 
-      it('Remove an user', (done) => {
-        acl.removeUser('dimitri', (err1) => {
-          expect(!err1);
+  describe('Read role\'s users', () => {
+    it('Run roleUsers function', (done) => {
+      acl.addUserRoles('harry', 'admin', (err1) => {
+        if (err1) done(err1);
+
+        acl.roleUsers('admin', (err2, users) => {
+          if (err2) done(err2);
+          expect(users).toContain('harry');
           done();
         });
+      });
+    });
+  });
+
+  describe('Allow', () => {
+    it('Admin view/add/edit/delete users', (done) => {
+      acl.allow('admin', 'users', ['add', 'edit', 'view', 'delete'], (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Foo view/edit blogs', (done) => {
+      acl.allow('foo', 'blogs', ['edit', 'view'], (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Bar to view/delete blogs', (done) => {
+      acl.allow('bar', 'blogs', ['view', 'delete'], (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('Add role parents', () => {
+    it('Add foot and bar roles into baz parent role', (done) => {
+      acl.addRoleParents('baz', ['foo', 'bar'], (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('Add user roles', () => {
+    it('Add them', (done) => {
+      acl.addUserRoles('dimitri', 'baz', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Add them with numeric userId', (done) => {
+      acl.addUserRoles(3, 'baz', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('allow admin to do anything', () => {
+    it('Add them', (done) => {
+      acl.allow('admin', ['blogs', 'forums'], '*', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('Arguments in one array', () => {
+    it('Give role fumanchu an array of resources and permissions', (done) => {
+      acl.allow(
+        [{
+          roles: 'fumanchu',
+          allows: [
+            {resources: 'blogs', permissions: 'get'},
+            {resources: ['forums', 'news'], permissions: ['get', 'put', 'delete']},
+            {resources: ['/path/file/file1.txt', '/path/file/file2.txt'], permissions: ['get', 'put', 'delete']},
+          ],
+        }],
+        (err) => {
+          expect(!err);
+          done();
+        },
+      );
+    });
+  });
+
+  describe('Add fumanchu role to suzanne', () => {
+    it('Do it', (done) => {
+      acl.addUserRoles('suzanne', 'fumanchu', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Do it (numeric userId)', (done) => {
+      acl.addUserRoles(4, 'fumanchu', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+
+  describe('Allowance queries', () => {
+    describe('IsAllowed', () => {
+      it('Can joed view blogs?', (done) => {
+        acl.isAllowed('joed', 'blogs', 'view', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can userId=0 view blogs?', (done) => {
+        acl.isAllowed(0, 'blogs', 'view', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can joed view forums?', (done) => {
+        acl.isAllowed('joed', 'forums', 'view', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can userId=0 view forums?', (done) => {
+        acl.isAllowed(0, 'forums', 'view', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can joed edit forums?', (done) => {
+        acl.isAllowed('joed', 'forums', 'edit', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can userId=0 edit forums?', (done) => {
+        acl.isAllowed(0, 'forums', 'edit', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can jsmith edit forums?', (done) => {
+        acl.isAllowed('jsmith', 'forums', 'edit', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can jsmith edit forums?', (done) => {
+        acl.isAllowed('jsmith', 'forums', 'edit', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+
+      it('Can jsmith edit blogs?', (done) => {
+        acl.isAllowed('jsmith', 'blogs', 'edit', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can test@test.com edit forums?', (done) => {
+        acl.isAllowed('test@test.com', 'forums', 'edit', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can test@test.com edit forums?', (done) => {
+        acl.isAllowed('test@test.com', 'forums', 'edit', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can test@test.com edit blogs?', (done) => {
+        acl.isAllowed('test@test.com', 'blogs', 'edit', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can userId=1 edit blogs?', (done) => {
+        acl.isAllowed(1, 'blogs', 'edit', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can jsmith edit, delete and clone blogs?', (done) => {
+        acl.isAllowed('jsmith', 'blogs', ['edit', 'view', 'clone'], (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can test@test.com edit, delete and clone blogs?', (done) => {
+        acl.isAllowed('test@test.com', 'blogs', ['edit', 'view', 'clone'], (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can userId=1 edit, delete and clone blogs?', (done) => {
+        acl.isAllowed(1, 'blogs', ['edit', 'view', 'clone'], (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can jsmith edit, clone blogs?', (done) => {
+        acl.isAllowed('jsmith', 'blogs', ['edit', 'clone'], (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can test@test.com edit, clone blogs?', (done) => {
+        acl.isAllowed('test@test.com', 'blogs', ['edit', 'clone'], (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can userId=1 edit, delete blogs?', (done) => {
+        acl.isAllowed(1, 'blogs', ['edit', 'clone'], (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can james add blogs?', (done) => {
+        acl.isAllowed('dimitri', 'blogs', 'add', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+
+      it('Can userId=3 add blogs?', (done) => {
+        acl.isAllowed(3, 'blogs', 'add', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can suzanne add blogs?', (done) => {
+        acl.isAllowed('suzanne', 'blogs', 'add', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can userId=4 add blogs?', (done) => {
+        acl.isAllowed(4, 'blogs', 'add', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can suzanne get blogs?', (done) => {
+        acl.isAllowed('suzanne', 'blogs', 'get', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can userId=4 get blogs?', (done) => {
+        acl.isAllowed(4, 'blogs', 'get', (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can suzanne delete and put news?', (done) => {
+        acl.isAllowed('suzanne', 'news', ['put', 'delete'], (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can userId=4 delete and put news?', (done) => {
+        acl.isAllowed(4, 'news', ['put', 'delete'], (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can suzanne delete and put forums?', (done) => {
+        acl.isAllowed('suzanne', 'forums', ['put', 'delete'], (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can userId=4 delete and put forums?', (done) => {
+        acl.isAllowed(4, 'forums', ['put', 'delete'], (err, allow) => {
+          expect(!err);
+          expect(allow);
+          done();
+        });
+      });
+
+      it('Can nobody view news?', (done) => {
+        acl.isAllowed('nobody', 'blogs', 'view', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+
+      it('Can nobody view nothing?', (done) => {
+        acl.isAllowed('nobody', 'nothing', 'view', (err, allow) => {
+          expect(!err);
+          expect(!allow);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('allowedPermissions', () => {
+    it('What permissions has james over blogs and forums?', (done) => {
+      acl.allowedPermissions('dimitri', ['blogs', 'forums'], (err, permissions) => {
+        expect(!err);
+        expect(permissions).toHaveProperty('blogs');
+        expect(permissions).toHaveProperty('forums');
+        expect(permissions.blogs).toContain('edit');
+        expect(permissions.blogs).toContain('view');
+        expect(permissions.blogs).toContain('delete');
+        expect(!permissions.forums.length);
+        done();
+      });
+    });
+
+    it('What permissions has userId=3 over blogs and forums?', (done) => {
+      acl.allowedPermissions(3, ['blogs', 'forums'], (err, permissions) => {
+        expect(!err);
+        expect(permissions).toHaveProperty('blogs');
+        expect(permissions).toHaveProperty('forums');
+        expect(permissions.blogs).toContain('edit');
+        expect(permissions.blogs).toContain('view');
+        expect(permissions.blogs).toContain('delete');
+        expect(!permissions.forums.length);
+        done();
+      });
+    });
+
+    it('What permissions has nonsenseUser over blogs and forums?', (done) => {
+      acl.allowedPermissions('nonsense', ['blogs', 'forums'], (err, permissions) => {
+        expect(!err);
+        expect(!permissions.forums.length);
+        expect(!permissions.blogs.length);
+        done();
+      });
+    });
+  });
+
+  describe('WhatResources queries', () => {
+    it('What resources have "bar" some rights on?', (done) => {
+      acl.whatResources('bar', (err, resources) => {
+        expect(err).toBeNull();
+        expect(resources.blogs).toContain('view');
+        expect(resources.blogs).toContain('delete');
+        done();
+      });
+    });
+
+    it('What resources have "bar" view rights on?', (done) => {
+      acl.whatResources('bar', 'view', (err, resources) => {
+        expect(err).toBeNull();
+        expect(resources).toContain('blogs');
+        done();
+      });
+    });
+
+    it('What resources have "fumanchu" some rights on?', (done) => {
+      acl.whatResources('fumanchu', (err, resources) => {
+        expect(err).toBeNull();
+        expect(resources).toHaveProperty('blogs', ['get']);
+        expect(resources.forums).toContain('get');
+        expect(resources.forums).toContain('put');
+        expect(resources.forums).toContain('delete');
+        expect(resources.news).toContain('get');
+        expect(resources.news).toContain('put');
+        expect(resources.news).toContain('delete');
+        expect(resources['/path/file/file1.txt']).toContain('get');
+        expect(resources['/path/file/file1.txt']).toContain('put');
+        expect(resources['/path/file/file1.txt']).toContain('delete');
+        expect(resources['/path/file/file2.txt']).toContain('get');
+        expect(resources['/path/file/file2.txt']).toContain('put');
+        expect(resources['/path/file/file2.txt']).toContain('delete');
+        done();
+      });
+    });
+
+    it('What resources have "baz" some rights on?', (done) => {
+      acl.whatResources('baz', (err, resources) => {
+        expect(err).toBeNull();
+        expect(resources.blogs).toContain('edit');
+        expect(resources.blogs).toContain('view');
+        expect(resources.blogs).toContain('delete');
+        done();
+      });
+    });
+  });
+
+  describe('removeAllow', () => {
+    it('Remove get permissions from resources blogs and forums from role fumanchu', (done) => {
+      acl.removeAllow('fumanchu', ['blogs', 'forums'], 'get', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Remove delete and put permissions from resource news from role fumanchu', (done) => {
+      acl.removeAllow('fumanchu', 'news', 'delete', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Remove view permissions from resource blogs from role bar', (done) => {
+      acl.removeAllow('bar', 'blogs', 'view', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('See if permissions were removed', () => {
+    it('What resources have "fumanchu" some rights on after removed some of them?', (done) => {
+      acl.whatResources('fumanchu', (err, resources) => {
+        expect(err).toBeNull();
+        expect(resources).not.toContain('blogs');
+        expect(resources).toHaveProperty('news');
+        expect(resources.news).toContain('get');
+        expect(resources.news).toContain('put');
+        expect(resources).not.toContain('delete');
+        expect(resources.forums).toContain('put');
+        expect(resources.forums).toContain('delete');
+        done();
+      });
+    });
+  });
+
+  describe('RemoveRole', () => {
+    it('Remove role fumanchu', (done) => {
+      acl.removeRole('fumanchu', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Remove role member', (done) => {
+      acl.removeRole('member', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Remove role foo', (done) => {
+      acl.removeRole('foo', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('Was role removed?', () => {
+    it('What resources have "fumanchu" some rights on after removed?', (done) => {
+      acl.whatResources('fumanchu', (err, resources) => {
+        expect(!err);
+        expect(!Object.keys(resources).length);
+        done();
+      });
+    });
+
+    it('What resources have "member" some rights on after removed?', (done) => {
+      acl.whatResources('member', (err, resources) => {
+        expect(!err);
+        expect(!Object.keys(resources).length);
+        done();
+      });
+    });
+
+    describe('Allowed permissions', () => {
+      it('What permissions has jsmith over blogs and forums?', (done) => {
+        acl.allowedPermissions('jsmith', ['blogs', 'forums'], (err, permissions) => {
+          expect(!err);
+          expect(!permissions.blogs);
+          expect(!permissions.forums);
+          done();
+        });
+      });
+
+      it('What permissions has test@test.com over blogs and forums?', (done) => {
+        acl.allowedPermissions('test@test.com', ['blogs', 'forums'], (err, permissions) => {
+          expect(!err);
+          expect(!permissions.blogs);
+          expect(!permissions.forums);
+          done();
+        });
+      });
+
+      it('What permissions has james over blogs?', (done) => {
+        acl.allowedPermissions('dimitri', 'blogs', (err, permissions) => {
+          expect(!err);
+          expect(permissions.blogs).toContain('delete');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('RoleParentRemoval', () => {
+    beforeAll((done) => {
+      acl.allow('parent1', 'x', 'read1')
+        .then(() => acl.allow('parent2', 'x', 'read2'))
+        .then(() => acl.allow('parent3', 'x', 'read3'))
+        .then(() => acl.allow('parent4', 'x', 'read4'))
+        .then(() => acl.allow('parent5', 'x', 'read5'))
+        .then(() => acl.addRoleParents('child', ['parent1', 'parent2', 'parent3', 'parent4', 'parent5']))
+        .then(() => done());
+    });
+
+    it('Environment check', (done) => {
+      acl.whatResources('child')
+        .then((resources) => {
+          expect(resources.x.length === 5);
+          expect(resources.x).toContain('read1');
+          expect(resources.x).toContain('read2');
+          expect(resources.x).toContain('read3');
+          expect(resources.x).toContain('read4');
+          expect(resources.x).toContain('read5');
+          done();
+        });
+    });
+
+    it('Operation uses a callback when removing a specific parent role', (done) => {
+      acl.removeRoleParents('child', 'parentX', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Operation uses a callback when removing multiple specific parent roles', (done) => {
+      acl.removeRoleParents('child', ['parentX', 'parentY'], (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Remove parent role "parentX" from role "child"', (done) => {
+      acl.removeRoleParents('child', 'parentX')
+        .then(() => acl.whatResources('child'))
+        .then((resources) => {
+          expect(resources.x.length === 5);
+          expect(resources.x).toContain('read1');
+          expect(resources.x).toContain('read2');
+          expect(resources.x).toContain('read3');
+          expect(resources.x).toContain('read4');
+          expect(resources.x).toContain('read5');
+          done();
+        });
+    });
+
+    it('Remove parent role "parent1" from role "child"', (done) => {
+      acl.removeRoleParents('child', 'parent1')
+        .then(() => acl.whatResources('child'))
+        .then((resources) => {
+          expect(resources.x.length === 4);
+          expect(resources.x).toContain('read2');
+          expect(resources.x).toContain('read3');
+          expect(resources.x).toContain('read4');
+          expect(resources.x).toContain('read5');
+          done();
+        });
+    });
+
+    it('Remove parent roles "parent2" & "parent3" from role "child"', (done) => {
+      acl.removeRoleParents('child', ['parent2', 'parent3'])
+        .then(() => acl.whatResources('child'))
+        .then((resources) => {
+          expect(resources.x.length === 2);
+          expect(resources.x).toContain('read4');
+          expect(resources.x).toContain('read5');
+          done();
+        });
+    });
+
+    it('Remove all parent roles from role "child"', (done) => {
+      acl.removeRoleParents('child')
+        .then(() => acl.whatResources('child'))
+        .then((resources) => {
+          expect(resources).not.toHaveProperty('x');
+          done();
+        });
+    });
+
+    it('Remove all parent roles from role "child" with no parents', (done) => {
+      acl.removeRoleParents('child')
+        .then(() => acl.whatResources('child'))
+        .then((resources) => {
+          expect(resources).not.toHaveProperty('x');
+          done();
+        });
+    });
+
+    it('Remove parent role "parent1" from role "child" with no parents', (done) => {
+      acl.removeRoleParents('child', 'parent1')
+        .then(() => acl.whatResources('child'))
+        .then((resources) => {
+          expect(resources).not.toHaveProperty('x');
+          done();
+        });
+    });
+
+    it('Operation uses a callback when removing all parent roles', (done) => {
+      acl.removeRoleParents('child', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('RemoveResource', () => {
+    it('Remove resource blogs', (done) => {
+      acl.removeResource('blogs', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Remove resource users', (done) => {
+      acl.removeResource('users', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('AllowedPermissions', () => {
+    it('What permissions has james over blogs?', (done) => {
+      acl.allowedPermissions('dimitri', 'blogs', (err, permissions) => {
+        expect(err).toBeNull();
+        expect(permissions).toHaveProperty('blogs');
+        expect(!permissions.blogs.length);
+        done();
+      });
+    });
+
+    it('What permissions has userId=4 over blogs?', (done) => {
+      acl.allowedPermissions(4, 'blogs')
+        .then((permissions) => {
+          expect(permissions).toHaveProperty('blogs');
+          expect(!permissions.blogs.length);
+          done();
+        });
+    });
+  });
+
+  describe('WhatResources', () => {
+    it('What resources have "baz" some rights on after removed blogs?', (done) => {
+      acl.whatResources('baz', (err, resources) => {
+        expect(!err);
+        expect(typeof resources === 'object');
+        expect(!Object.keys(resources).length);
+        done();
+      });
+    });
+
+    it('What resources have "admin" some rights on after removed users resource?', (done) => {
+      acl.whatResources('admin', (err, resources) => {
+        expect(!err);
+        expect(resources).not.toContain('users');
+        expect(resources).not.toContain('blogs');
+        done();
+      });
+    });
+  });
+
+  describe('Remove user roles', () => {
+    it('Remove role guest from joed', (done) => {
+      acl.removeUserRoles('joed', 'guest', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Remove role guest from userId=0', (done) => {
+      acl.removeUserRoles(0, 'guest', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+    it('Remove role admin from harry', (done) => {
+      acl.removeUserRoles('harry', 'admin', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Remove role admin from userId=2', (done) => {
+      acl.removeUserRoles(2, 'admin', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+  });
+
+  describe('Were roles removed?', () => {
+    it('What permissions has harry over forums and blogs?', (done) => {
+      acl.allowedPermissions('harry', ['forums', 'blogs'], (err, permissions) => {
+        expect(!err);
+        expect(typeof permissions === 'object');
+        expect(!permissions.forums.length);
+        done();
+      });
+    });
+
+    it('What permissions has userId=2 over forums and blogs?', (done) => {
+      acl.allowedPermissions(2, ['forums', 'blogs'], (err, permissions) => {
+        expect(!err);
+        expect(typeof permissions === 'object');
+        expect(!permissions.forums.length);
+        done();
+      });
+    });
+  });
+
+  describe('RemoveAllow is removing all permissions', () => {
+    it('Add roles/resources/permissions', () => {
+      acl.addUserRoles('jannette', 'member')
+        .then(() => acl.allow('member', 'blogs', ['view', 'update']))
+        .then(() => acl.isAllowed('jannette', 'blogs', 'view'))
+        .then((isAllowed) => expect(isAllowed).toBeTruthy())
+        .then(() => acl.removeAllow('member', 'blogs', 'update'))
+        .then(() => acl.isAllowed('jannette', 'blogs', 'view'))
+        .then((isAllowed) => expect(isAllowed).toBeTruthy())
+        .then(() => acl.isAllowed('jannette', 'blogs', 'update'))
+        .then((isAllowed) => expect(isAllowed).toBeFalsy())
+        .then(() => acl.removeAllow('member', 'blogs', 'view'))
+        .then(() => acl.isAllowed('jannette', 'blogs', 'view'))
+        .then((isAllowed) => expect(isAllowed).toBeFalsy());
+    });
+  });
+
+  describe('Removing a role removes the entire "allows" document.', () => {
+    it('Add roles/resources/permissions', (done) => {
+      acl.allow(['role1', 'role2', 'role3'], ['res1', 'res2', 'res3'], ['perm1', 'perm2', 'perm3'], (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Add user roles and parent roles', (done) => {
+      acl.addUserRoles('user1', 'role1', (err1) => {
+        expect(!err1);
+
+        acl.addRoleParents('role1', 'parentRole1', (err2) => {
+          expect(!err2);
+          done();
+        });
+      });
+    });
+
+    it('Add user roles and parent roles', (done) => {
+      acl.addUserRoles(1, 'role1', (err1) => {
+        expect(!err1);
+
+        acl.addRoleParents('role1', 'parentRole1', (err2) => {
+          expect(!err2);
+          done();
+        });
+      });
+    });
+
+    it('Verify that roles have permissions as assigned', (done) => {
+      acl.whatResources('role1', (err1, res1) => {
+        expect(!err1);
+        expect(res1.res1.sort()).toEqual(['perm1', 'perm2', 'perm3']);
+
+        acl.whatResources('role2', (err2, res2) => {
+          expect(!err2);
+          expect(res2.res1.sort()).toEqual(['perm1', 'perm2', 'perm3']);
+          done();
+        });
+      });
+    });
+
+    it('Remove role "role1"', (done) => {
+      acl.removeRole('role1', (err) => {
+        expect(!err);
+        done();
+      });
+    });
+
+    it('Verify that "role1" has no permissions and "role2" has permissions intact', (done) => {
+      acl.removeRole('role1', (err) => {
+        expect(!err);
+
+        acl.whatResources('role1', (err1, res1) => {
+          expect(!Object.keys(res1).length);
+
+          acl.whatResources('role2', (err2, res2) => {
+            expect(res2.res1.sort()).toEqual(['perm1', 'perm2', 'perm3']);
+            done();
+          });
+        });
+      });
+    });
+
+    it('Remove an user', (done) => {
+      acl.removeUser('dimitri', (err1) => {
+        expect(!err1);
+        done();
       });
     });
   });

--- a/__tests__/tests.js
+++ b/__tests__/tests.js
@@ -2,6 +2,7 @@
 import Redis from 'redis';
 import {MongoClient} from 'mongodb';
 import Sequelize from 'sequelize';
+import httpMocks from 'node-mocks-http';
 import Acl from '../src/classes/acl';
 import MemoryStore from '../src/stores/memory';
 import RedisStore from '../src/stores/redis';
@@ -36,7 +37,7 @@ let mongoClient = null;
         });
         sequelize.authenticate()
           .then(() => {
-            acl = new Acl(new SequelizeStore(sequelize), {prefix: 'acl_'});
+            acl = new Acl(new SequelizeStore(sequelize, {prefix: 'acl_'}));
             done();
           });
       }
@@ -133,6 +134,23 @@ let mongoClient = null;
               done();
             });
           });
+        });
+      });
+    });
+
+    describe('Middleware', () => {
+      it('should fallback to dummy logger', (done) => {
+        const request = httpMocks.createRequest({
+          method: 'GET',
+          url: '/blogs',
+        });
+
+        const response = httpMocks.createResponse();
+
+        acl.middleware(0, 'joed', 'GET')(request, response, (err) => {
+          // TODO returns HttpError 403
+          expect(err);
+          done();
         });
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,6 +182,16 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true
     },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -2000,6 +2010,12 @@
         "combined-stream": "1.0.6",
         "mime-types": "2.1.18"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fs-readdir-recursive": {
       "version": "1.1.0",
@@ -4590,6 +4606,12 @@
         "tmpl": "1.0.4"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
@@ -4605,6 +4627,12 @@
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -4613,6 +4641,12 @@
       "requires": {
         "readable-stream": "2.3.2"
       }
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
@@ -4634,6 +4668,12 @@
         "parse-glob": "3.0.4",
         "regex-cache": "0.4.4"
       }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.33.0",
@@ -4768,11 +4808,41 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "net": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
+      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g=",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
+    },
+    "node-mocks-http": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.5.8.tgz",
+      "integrity": "sha512-M0hzy8zR8vPy5WQcfRnFHZ0Rzi+Ru3P7QLa4NZQAnxbFHyiwLgzseuvfnItCfa15Q2sWJNNxjNssjpJiQ+wocA==",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.5",
+        "depd": "1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "mime": "1.6.0",
+        "net": "1.0.2",
+        "parseurl": "1.3.2",
+        "range-parser": "1.2.0",
+        "type-is": "1.6.16"
+      }
     },
     "node-notifier": {
       "version": "5.2.1",
@@ -5006,6 +5076,12 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -5229,6 +5305,12 @@
           }
         }
       }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
     },
     "read-pkg": {
       "version": "1.1.0",
@@ -6065,6 +6147,16 @@
       "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
+      }
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
       }
     },
     "typedarray": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aclify",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aclify",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Node Access Control List (ACL)",
   "license": "MIT",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "eslint-plugin-flowtype": "^2.45.0",
     "eslint-plugin-import": "~2.8.0",
     "flow-bin": "~0.66.0",
-    "jest": "~22.4.0"
+    "jest": "~22.4.0",
+    "node-mocks-http": "^1.5.8"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/classes/acl.js
+++ b/src/classes/acl.js
@@ -9,13 +9,7 @@ export default class Acl extends Common {
   store: {};
   options: {};
   logger: {
-    info: () => {},
-    error: () => {},
-    trace: () => {},
-    warn: () => {},
-    fatal: () => {},
     debug: () => {},
-    log: () => {},
   };
 
   /**

--- a/src/classes/acl.js
+++ b/src/classes/acl.js
@@ -8,7 +8,15 @@ import HttpError from './http_error';
 export default class Acl extends Common {
   store: {};
   options: {};
-  logger: {};
+  logger: {
+    info: () => {},
+    error: () => {},
+    trace: () => {},
+    warn: () => {},
+    fatal: () => {},
+    debug: () => {},
+    log: () => {},
+  };
 
   /**
    * @description Create ACL class and promisify store methods.
@@ -16,7 +24,7 @@ export default class Acl extends Common {
    * @param logger
    * @param options
    */
-  constructor(store: {}, logger: {} = {}, options: {} = {}) {
+  constructor(store: {}, logger: {}, options: {} = {}) {
     super();
     this.options = _.extend({
       buckets: {


### PR DESCRIPTION
Issue: #16 

- logger debug function added (thanks @eiabea)
- middleware tests added (thanks @eiabea)
- tests use now the npm entry point (instead of direct class usage)